### PR TITLE
Remove useless packages

### DIFF
--- a/bin/hello.js
+++ b/bin/hello.js
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
-const chalk = require('chalk');
-
 const welcome = `
  _| _  _ |_  _  _ | _ |_ 
 (_|(_)(_)|_)(_)(_)|(_||_)
 `;
-console.log(chalk.greenBright(welcome));
+console.log('\x1b[92m', welcome);

--- a/package.json
+++ b/package.json
@@ -15,12 +15,9 @@
   ],
   "author": "dooboolab@gmail.com",
   "license": "ISC",
-  "dependencies": {
-    "chalk": "^2.4.2",
-    "eslint": "^6.0.0"
-  },
   "devDependencies": {
     "babel-eslint": "^10.0.1",
+    "eslint": "^6.0.0",
     "eslint-config-standard": "^13.0.1",
     "eslint-plugin-import": "^2.17.3",
     "eslint-plugin-node": "^10.0.0",


### PR DESCRIPTION
```
npx: installed 112 in 5.783s
└─ dooboolab-welcome@1.1.0
   └─ chalk@2.4.2
      ├─ supports-color@5.5.0
      │  └─ has-flag@3.0.0
      ├─ escape-string-regexp@1.0.5
      └─ ansi-styles@3.2.1
         └─ color-convert@1.9.3
            └─ color-name@1.1.3
```

Maybe you don't need any package to print a simple message.