### PR TITLE
move @dooboo/eslint-config to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,8 @@
   "license": "ISC",
   "devDependencies": {
     "eslint": "^7.25.0",
-    "prettier": "^2.2.1"
-  },
-  "dependencies": {
+    "prettier": "^2.2.1",
     "@dooboo/eslint-config": "^0.7.0"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
to avoid "unmet peer dependency" warnings. fixes #11 